### PR TITLE
Fix for 404 Exception/Warning if file is missing on Fritzbox

### DIFF
--- a/src/fritzsoap.php
+++ b/src/fritzsoap.php
@@ -158,10 +158,13 @@ class fritzsoap
     private function getServiceXML(string $xmlFile, string $node): array
     {
         $result = [];
-        $xml = @simplexml_load_file($xmlFile);
-        if ($xml != false) {
-            $xml->registerXPathNamespace('fb', $xml->getNameSpaces(false)[""]);
-            $result = $xml->xpath("//fb:$node");
+        $file_headers = @get_headers($xmlFile);
+        if (substr($file_headers[0], -13) != '404 Not Found') {
+            $xml = @simplexml_load_file($xmlFile);
+            if ($xml != false) {
+                $xml->registerXPathNamespace('fb', $xml->getNameSpaces(false)[""]);
+                $result = $xml->xpath("//fb:$node");
+            }
         }
 
         return $result;

--- a/src/fritzsoap.php
+++ b/src/fritzsoap.php
@@ -159,7 +159,7 @@ class fritzsoap
     {
         $result = [];
         $file_headers = @get_headers($xmlFile);
-        if (substr($file_headers[0], -13) != '404 Not Found') {
+        if ($file_headers !== false && substr($file_headers[0], -13) != '404 Not Found') {
             $xml = @simplexml_load_file($xmlFile);
             if ($xml != false) {
                 $xml->registerXPathNamespace('fb', $xml->getNameSpaces(false)[""]);


### PR DESCRIPTION
Additional parameters which could be set for simplexml_load_file like LIBXML_NOERROR or LIBXML_NOWARNING did not solve the issue, but this workaround works.